### PR TITLE
🐛 Fix ESM support

### DIFF
--- a/fixup
+++ b/fixup
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+#   Add package.json files to cjs/mjs subtrees
+#
+
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF
+
+find src -name '*.d.ts' -exec cp {} dist/cjs \;
+find src -name '*.d.ts' -exec cp {} dist/esm \;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "openapi-typescript-fetch": "git+https://github.com/ajaishankar/openapi-typescript-fetch.git"
+        "openapi-typescript-fetch": "git+https://github.com/lmachens/openapi-typescript-fetch.git"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -26,8 +26,8 @@
         "whatwg-fetch": "^3.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "npm": ">= 7.0.0"
+        "node": ">= 16.0.0",
+        "npm": ">= 8.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4026,7 +4026,7 @@
     },
     "node_modules/openapi-typescript-fetch": {
       "version": "1.1.2",
-      "resolved": "git+ssh://git@github.com/ajaishankar/openapi-typescript-fetch.git#b62ee714e645c14b8e07c98aaaa53880e7d6c847",
+      "resolved": "git+ssh://git@github.com/lmachens/openapi-typescript-fetch.git#57922a9cb46810fb8ccd9eb87fcdeb5bc33ba9dd",
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0",
@@ -8231,8 +8231,8 @@
       }
     },
     "openapi-typescript-fetch": {
-      "version": "git+ssh://git@github.com/ajaishankar/openapi-typescript-fetch.git#b62ee714e645c14b8e07c98aaaa53880e7d6c847",
-      "from": "openapi-typescript-fetch@git+https://github.com/ajaishankar/openapi-typescript-fetch.git"
+      "version": "git+ssh://git@github.com/lmachens/openapi-typescript-fetch.git#57922a9cb46810fb8ccd9eb87fcdeb5bc33ba9dd",
+      "from": "openapi-typescript-fetch@git+https://github.com/lmachens/openapi-typescript-fetch.git"
     },
     "optionator": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     "browser": "./dist/esm/index.js",
     "import": "./dist/esm/index.js",
@@ -33,13 +34,13 @@
   "homepage": "https://github.com/playt-net/client#readme",
   "scripts": {
     "clean": "rimraf './dist'",
-    "build": "npm run clean && tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json",
+    "build": "npm run clean && tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json && ./fixup",
     "generate": "openapi-typescript https://playt-backend-xbwjl.ondigitalocean.app/v3/api-docs --output src/types.ts --prettier-config .prettierrc.json",
     "test": "jest",
     "typecheck": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
-    "openapi-typescript-fetch": "git+https://github.com/ajaishankar/openapi-typescript-fetch.git"
+    "openapi-typescript-fetch": "git+https://github.com/lmachens/openapi-typescript-fetch.git"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
-import {
-  ApiError,
+import type {
   ApiResponse,
-  Fetcher,
   Middleware,
+  ApiError as ApiErrorType,
 } from 'openapi-typescript-fetch';
+import { ApiError, Fetcher } from 'openapi-typescript-fetch';
+
 import type { paths, components, operations } from './types';
 export type { paths, components, operations, ApiResponse };
+
 export { ApiError };
 
 export type ClientCredentials = {
@@ -49,7 +51,7 @@ export const PlaytClient = ({
       const response = await next(url, init);
       return response;
     } catch (error) {
-      const { status } = error as ApiError;
+      const { status } = error as ApiErrorType;
 
       if (status === 401 && userAuth?.refreshToken && onRequestRefresh) {
         const refreshedUserAuth = await onRequestRefresh();

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "./dist/cjs"
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "es2015"
   },
   "extends": "./tsconfig.json",
   "include": ["src"]

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "ES2020",
-    "outDir": "./dist/esm"
+    "module": "esnext",
+    "outDir": "./dist/esm",
+    "target": "esnext"
   },
   "extends": "./tsconfig.json",
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,21 @@
     "baseUrl": "./src",
     "declaration": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "dom.iterable", "ES2020"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "moduleResolution": "Node",
-    "noImplicitReturns": true,
-    "removeComments": true,
-    "sourceMap": true,
     "strict": true,
-    "target": "ES2015",
-    "useDefineForClassFields": true
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "inlineSourceMap": false,
+    "listEmittedFiles": false,
+    "listFiles": false,
+    "noFallthroughCasesInSwitch": true,
+    "pretty": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "traceResolution": false,
+    "types": ["node", "jest"]
   },
   "include": ["src", "test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "noFallthroughCasesInSwitch": true,
     "pretty": true,
     "resolveJsonModule": true,
-    "rootDir": "src",
     "skipLibCheck": true,
     "traceResolution": false,
     "types": ["node", "jest"]


### PR DESCRIPTION
I faced the issue that I could not import this module as ESM.
After some research, I think it's related to missing package.json to specify type in the distributions.
See https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html for an example.

This pull request adds package.json in the dist folders with module commonjs/module.

`openapi-typescript-fetch` targets a fork until this is resolved:
https://github.com/ajaishankar/openapi-typescript-fetch/pull/24