### PR TITLE
🐛 avoid double slashes in fetch URLs

### DIFF
--- a/src/test/fetch.test.mts
+++ b/src/test/fetch.test.mts
@@ -40,8 +40,8 @@ describe('fetch', () => {
       throw Error('Should fail without valid query');
     } catch (error) {
       const { status, statusText } = error as ApiError;
-      expect(status).toBe(400);
-      expect(statusText).toBe('Bad Request');
+      expect(status).toBe(401);
+      expect(statusText).toBe('Unauthorized');
     }
   });
   it('submitScore', async () => {
@@ -54,8 +54,9 @@ describe('fetch', () => {
       throw Error('Should fail without valid query');
     } catch (error) {
       const { status, statusText } = error as ApiError;
-      expect(status).toBe(400);
-      expect(statusText).toBe('Bad Request');
+      console.log(error);
+      expect(status).toBe(401);
+      expect(statusText).toBe('Unauthorized');
     }
   });
   it('submitTutorialScore', async () => {
@@ -81,8 +82,8 @@ describe('fetch', () => {
       throw Error('Should fail without valid query');
     } catch (error) {
       const { status, statusText } = error as ApiError;
-      expect(status).toBe(400);
-      expect(statusText).toBe('Bad Request');
+      expect(status).toBe(401);
+      expect(statusText).toBe('Unauthorized');
     }
   });
   it('getReplay', async () => {


### PR DESCRIPTION
By using proper URL operations instead of string concatenation.

Tested by linking into Rolling Rick configured with a trailing slash
base URL.

This fixes an issue where a base URL with a trailing slash resulting in
a double slash in the fetch URL would run into CORS issues because while
fun-fair does redirect the double slash to single slash, it does so
without CORS Allow.

I'll publish a client release afterwards, but it is not urgent to update
games to the new version. The base URLs are in our control so we can
just avoid the issue by not using trailins slash base URLs.

* Closes https://github.com/playt-net/fun-fair/issues/1196