### PR TITLE
🎨 prettier-ignore places where formatting breaks the build

### DIFF
--- a/src/fetcher/fetcher.mts
+++ b/src/fetcher/fetcher.mts
@@ -218,6 +218,8 @@ function fetcher<Paths>() {
       middlewares.push(...(config.use || []));
     },
     use: (mw: Middleware) => middlewares.push(mw),
+    // https://github.com/prettier/prettier/issues/14518
+    // prettier-ignore
     path: <P extends keyof Paths,>(path: P) => ({
       method: <M extends keyof Paths[P],>(method: M) => ({
         create: ((queryParams?: Record<string, true | 1>) =>
@@ -238,5 +240,6 @@ function fetcher<Paths>() {
 }
 
 export const Fetcher = {
+  // prettier-ignore
   for: <Paths extends OpenapiPaths<Paths>,>() => fetcher<Paths>(),
 };


### PR DESCRIPTION
Prettier tries to remove type parameter trailing commas in fetcher.mts,
but doing so causes build errors because it makes the syntax ambiguous
with JSX, which is not allowed in .mts even when JSX is disabled.
