### PR TITLE
:wastebasket: Use submitScore in place of submitTutorialScore

### DIFF
--- a/src/index.mts
+++ b/src/index.mts
@@ -37,22 +37,22 @@ const PlaytApiClient = function ({
     .method('post')
     .create();
   const quitMatch = fetcher.path('/api/matches/quit').method('post').create();
-  const submitTutorialScore = fetcher
-    .path('/api/tutorials/scores')
-    .method('post')
-    .create();
   const submitReplay = fetcher.path('/api/replays').method('post').create();
   const getReplay = fetcher.path('/api/replays').method('get').create();
+
+  const submitScoreWithTimestamp = ({
+    timestamp = new Date().toISOString(),
+    ...args
+  }: Parameters<typeof submitScore>[0]) => submitScore({ timestamp, ...args });
 
   return {
     fetcher,
     searchMatch,
-    submitScore: ({
-      timestamp = new Date().toISOString(),
-      ...args
-    }: Parameters<typeof submitScore>[0]) =>
-      submitScore({ timestamp, ...args }),
-    submitTutorialScore,
+    submitScore: submitScoreWithTimestamp,
+    /**
+     * @deprecated Use submitScore instead
+     */
+    submitTutorialScore: submitScoreWithTimestamp,
     submitReplay,
     getReplay,
     quitMatch,

--- a/src/test/fetch.test.mts
+++ b/src/test/fetch.test.mts
@@ -63,8 +63,8 @@ describe('fetch', () => {
     });
     await expect(promise).rejects.toThrowError(
       expect.objectContaining({
-        status: 404,
-        statusText: 'Not Found',
+        status: 401,
+        statusText: 'Unauthorized',
       })
     );
   });


### PR DESCRIPTION
Perhaps I am missing something, but to me `submitTutorialScore` looks basically identical and just misses the gameKey-validation on our side, which is negligible, as it is being used inside the `PlaytApiClient`, so its authorized anyway.

We should sunset it.