### PR TITLE
:memo: Catch up with the api-docs removal of /api/tutorials/scores

### DIFF
--- a/src/types.mts
+++ b/src/types.mts
@@ -195,31 +195,6 @@ export interface paths {
       };
     };
   };
-  '/api/tutorials/scores': {
-    /** The score depends on the game and should be an accumulated score of the user at a given time. Previously submitted scores will be ignored when a player has surrendered or is timed out. Submitting a final score or surrendering will finalise the match for the given player and no subsequent updates can be posted. */
-    post: {
-      responses: {
-        200: {
-          content: {
-            'application/json': {
-              /** @enum {string} */
-              message: 'success';
-            };
-          };
-        };
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            playerToken: string;
-            score: number;
-            finalSnapshot?: boolean | null;
-            surrender?: boolean | null;
-          };
-        };
-      };
-    };
-  };
   '/api/anybrain/info': {
     /** Retrieves the user and match id for a given player token */
     get: {


### PR DESCRIPTION
... I'd say we don't need to perform a release afterwards, as that already hasn't been used.