### PR TITLE
♻️ Add quitMatch to the browserClient

### DIFF
--- a/src/browser.mts
+++ b/src/browser.mts
@@ -122,12 +122,21 @@ const PlaytBrowserClient = ({
 		});
 	};
 
+	const quitMatch = async ({
+		playerToken,
+	}: operations["quitMatch"]["requestBody"]["content"]["application/json"]) => {
+		await fetcher.path("/api/matches/quit").method("post").create()({
+			playerToken,
+		});
+	};
+
 	return {
 		initialize,
 		startMatch,
 		stopMatch,
 		reportFatalError,
 		updatePlayerSettings,
+		quitMatch,
 	};
 };
 

--- a/src/index.mts
+++ b/src/index.mts
@@ -83,6 +83,9 @@ const PlaytApiClient = ({
 		submitTutorialScore: submitScoreWithTimestamp,
 		submitReplay,
 		getReplay,
+		/**
+		 * @deprecated quitMatch should be called from the browser as it is faster and more reliable
+		 */
 		quitMatch,
 	};
 };


### PR DESCRIPTION
@mmplayt suggested calling the quitMatch directly from the browser, so I implemented that functionality in the browserClient. The quitMatch in the apiClient is there for compatibility reasons and if we ever need to quit a game forcefully via the server.